### PR TITLE
Toggling dispensers updated

### DIFF
--- a/src/main/java/carpetextra/helpers/CarpetDispenserBehaviours.java
+++ b/src/main/java/carpetextra/helpers/CarpetDispenserBehaviours.java
@@ -138,8 +138,8 @@ public class CarpetDispenserBehaviours
         private static Set<Block> toggleable = Sets.newHashSet(
             Blocks.STONE_BUTTON, Blocks.ACACIA_BUTTON, Blocks.BIRCH_BUTTON, Blocks.DARK_OAK_BUTTON,
             Blocks.JUNGLE_BUTTON, Blocks.OAK_BUTTON, Blocks.SPRUCE_BUTTON, Blocks.REPEATER, 
-            Blocks.COMPARATOR, Blocks.LEVER, Blocks.DAYLIGHT_DETECTOR, Blocks.REDSTONE_ORE, Blocks.BELL,
-            Blocks.JUKEBOX
+            Blocks.COMPARATOR, Blocks.LEVER, Blocks.DAYLIGHT_DETECTOR, Blocks.REDSTONE_ORE,
+            Blocks.JUKEBOX, Blocks.NOTE_BLOCK
         );
 
         @Override

--- a/src/main/java/carpetextra/mixins/NoteBlockMixin.java
+++ b/src/main/java/carpetextra/mixins/NoteBlockMixin.java
@@ -1,0 +1,25 @@
+package carpetextra.mixins;
+
+import net.minecraft.block.NoteBlock;
+import net.minecraft.entity.player.PlayerAbilities;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(NoteBlock.class)
+public abstract class NoteBlockMixin {
+    @Redirect(
+        method = "onUse",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/entity/player/PlayerEntity;incrementStat(Lnet/minecraft/util/Identifier;)V"
+        )
+    )
+    private void onIncrementStat(PlayerEntity player, Identifier ident) {
+        if(player == null) return;
+        player.incrementStat(ident);
+        return;
+    }
+}

--- a/src/main/resources/carpet-extra.mixins.json
+++ b/src/main/resources/carpet-extra.mixins.json
@@ -28,7 +28,7 @@
     "VillagerTaskListProvider_wartFarmMixin",
     "VillagerProfession_wartFarmMixin",
     "SecondaryPointOfInterestSensor_wartFarmMixin",
-
+    "NoteBlockMixin",
 
     "PlayerEntityMixin",
     "PistonBlockMixin",


### PR DESCRIPTION
Removed bells because they are triggered by redstone now and added note blocks