### PR TITLE
[1.16] Fix obsidian dropping without proper tools

### DIFF
--- a/src/main/java/carpetextra/mixins/BlocksMixin.java
+++ b/src/main/java/carpetextra/mixins/BlocksMixin.java
@@ -27,6 +27,6 @@ public class BlocksMixin
             ordinal = 0))
     private static Block registerObsidian(String id, Block obsidian)
     {
-        return register("obsidian", new ObsidianBlock(Block.Settings.of(Material.STONE, MaterialColor.BLACK).strength(50.0F, 1200.0F)));
+        return register("obsidian", new ObsidianBlock(Block.Settings.of(Material.STONE, MaterialColor.BLACK).requiresTool().strength(50.0F, 1200.0F)));
     }
 }


### PR DESCRIPTION
In 1.16, vanilla code changed so in the block declarations you have to specify that the block requires the tool in order for it to drop itself as an item.
This wasn't changed when updating carpet-extra's mixins (BlocksMixin, for renewableLava I think), making obsidian drop with lower level tools and making it faster to break with those (according to the issue).
Fixes #112.