### PR TITLE
Chunk only unloads (when pot broken) if rose inside

### DIFF
--- a/src/main/java/carpetextra/mixins/FlowerPotBlockMixin.java
+++ b/src/main/java/carpetextra/mixins/FlowerPotBlockMixin.java
@@ -27,14 +27,14 @@ import java.util.Map;
 public abstract class FlowerPotBlockMixin extends Block
 {
     @Shadow @Final private static Map<Block, Block> CONTENT_TO_POTTED;
-    
+
     @Shadow @Final private Block content;
-    
+
     public FlowerPotBlockMixin(Settings block$Settings_1)
     {
         super(block$Settings_1);
     }
-    
+
     @Inject(method = "onUse", at = @At("HEAD"))
     private void onActivate(BlockState blockState_1, World world_1, BlockPos blockPos_1, PlayerEntity playerEntity_1, Hand hand_1, BlockHitResult blockHitResult_1, CallbackInfoReturnable<Boolean> cir)
     {
@@ -43,22 +43,22 @@ public abstract class FlowerPotBlockMixin extends Block
             ItemStack stack = playerEntity_1.getStackInHand(hand_1);
             Item item = stack.getItem();
             Block block = item instanceof BlockItem ? (Block) CONTENT_TO_POTTED.getOrDefault(((BlockItem) item).getBlock(), Blocks.AIR) : Blocks.AIR;
-            boolean boolean_1 = block == Blocks.AIR;
-            boolean boolean_2 = this.content == Blocks.AIR;
+            boolean blockNotPottable = block == Blocks.AIR;
+            boolean potEmpty = this.content == Blocks.AIR;
             ServerWorld serverWorld = (ServerWorld) world_1;
-    
-            if (boolean_1 != boolean_2 && (block == Blocks.POTTED_WITHER_ROSE || this.content == Blocks.WITHER_ROSE))
+
+            if (blockNotPottable != potEmpty && (block == Blocks.POTTED_WITHER_ROSE || this.content == Blocks.WITHER_ROSE))
             {
-                // System.out.println("Chunk load status = " + boolean_2);
-                serverWorld.setChunkForced(blockPos_1.getX() >> 4, blockPos_1.getZ() >> 4, boolean_2);
+                // System.out.println("Chunk load status = " + potEmpty);
+                serverWorld.setChunkForced(blockPos_1.getX() >> 4, blockPos_1.getZ() >> 4, potEmpty);
             }
         }
     }
-    
+
     @Override
     public void onBreak(World world_1, BlockPos blockPos_1, BlockState blockState_1, PlayerEntity playerEntity_1)
     {
-        if (CarpetExtraSettings.flowerPotChunkLoading && world_1.getServer() != null)
+        if (CarpetExtraSettings.flowerPotChunkLoading && world_1.getServer() != null && !world.isClient && this.content == Blocks.WITHER_ROSE)
         {
             ServerWorld serverWorld = (ServerWorld)world_1;
             serverWorld.setChunkForced(blockPos_1.getX() >> 4, blockPos_1.getZ() >> 4, false);


### PR DESCRIPTION
This is a small fix for a minor problem I noticed .

Previously onBreak() didn't check if the flower pot contained a wither rose or not before unloading the chunk. Now it checks that the pot contains a wither rose so breaking empty pots or pots with other flowers in the same chunk won't interfere with the system.
boolean_1 and boolean_2 in onActivate() were also renamed to better represent what they are.