### PR TITLE
Fixed several dispenserPlacesBlocks issues

### DIFF
--- a/src/main/java/carpetextra/helpers/CarpetDispenserBehaviours.java
+++ b/src/main/java/carpetextra/helpers/CarpetDispenserBehaviours.java
@@ -78,7 +78,7 @@ public class CarpetDispenserBehaviours
         }
     
         @Override
-        protected ItemStack dispenseSilently(BlockPointer source, ItemStack stack)
+        public ItemStack dispenseSilently(BlockPointer source, ItemStack stack)
         {
             if (!CarpetExtraSettings.dispensersFillMinecarts)
             {
@@ -123,6 +123,8 @@ public class CarpetDispenserBehaviours
             }
             else
             {
+                if (stack.getItem() instanceof BlockItem && PlaceBlockDispenserBehavior.canPlace(((BlockItem) stack.getItem()).getBlock()))
+                    return PlaceBlockDispenserBehavior.getInstance().dispenseSilently(source, stack);
                 return super.dispenseSilently(source, stack);
             }
         }
@@ -191,11 +193,7 @@ public class CarpetDispenserBehaviours
             }
             if(failure) return stack;
             // fix here for now - if problem shows up next time, will need to fix it one level above.
-            if(
-                    CarpetExtraSettings.dispenserPlacesBlocks &&
-                    stack.getItem() instanceof BlockItem &&
-                    PlaceBlockDispenserBehavior.canPlace(((BlockItem) stack.getItem()).getBlock())
-            )
+            if (stack.getItem() instanceof BlockItem && PlaceBlockDispenserBehavior.canPlace(((BlockItem) stack.getItem()).getBlock()))
             {
                 return PlaceBlockDispenserBehavior.getInstance().dispenseSilently(source, stack);
             }

--- a/src/main/java/carpetextra/mixins/DispenserBehaviorCarpetsMixin.java
+++ b/src/main/java/carpetextra/mixins/DispenserBehaviorCarpetsMixin.java
@@ -1,0 +1,28 @@
+package carpetextra.mixins;
+
+import carpetextra.CarpetExtraSettings;
+import carpetextra.utils.PlaceBlockDispenserBehavior;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPointer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(targets = "net/minecraft/block/dispenser/DispenserBehavior$4")
+public abstract class DispenserBehaviorCarpetsMixin
+{
+    @SuppressWarnings("UnresolvedMixinReference")
+    @Inject(
+            method = "dispenseSilently(Lnet/minecraft/util/math/BlockPointer;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;",
+            at = @At(value = "INVOKE", shift = At.Shift.BEFORE,
+                    target = "Lnet/minecraft/block/dispenser/FallibleItemDispenserBehavior;dispenseSilently(Lnet/minecraft/util/math/BlockPointer;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;"),
+            cancellable = true
+    )
+    private void handleBlockPlacing(BlockPointer pointer, ItemStack stack, CallbackInfoReturnable<ItemStack> cir)
+    {
+        if (stack.getItem() instanceof BlockItem && PlaceBlockDispenserBehavior.canPlace(((BlockItem) stack.getItem()).getBlock()))
+            cir.setReturnValue(PlaceBlockDispenserBehavior.getInstance().dispenseSilently(pointer, stack));
+    }
+}

--- a/src/main/java/carpetextra/mixins/DispenserBehaviorChestMixin.java
+++ b/src/main/java/carpetextra/mixins/DispenserBehaviorChestMixin.java
@@ -1,0 +1,29 @@
+package carpetextra.mixins;
+
+import carpetextra.helpers.CarpetDispenserBehaviours;
+import carpetextra.utils.PlaceBlockDispenserBehavior;
+import net.minecraft.entity.vehicle.AbstractMinecartEntity;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPointer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(targets = "net/minecraft/block/dispenser/DispenserBehavior$5")
+public abstract class DispenserBehaviorChestMixin
+{
+    @SuppressWarnings("UnresolvedMixinReference")
+    @Inject(
+            method = "dispenseSilently(Lnet/minecraft/util/math/BlockPointer;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;",
+            at = @At(value = "INVOKE", shift = At.Shift.BEFORE,
+                    target = "Lnet/minecraft/block/dispenser/FallibleItemDispenserBehavior;dispenseSilently(Lnet/minecraft/util/math/BlockPointer;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;"),
+            cancellable = true
+    )
+    private void handleBlockPlacing(BlockPointer pointer, ItemStack stack, CallbackInfoReturnable<ItemStack> cir)
+    {
+        if (stack.getItem() instanceof BlockItem && PlaceBlockDispenserBehavior.canPlace(((BlockItem) stack.getItem()).getBlock()))
+            cir.setReturnValue(new CarpetDispenserBehaviours.MinecartDispenserBehaviour(AbstractMinecartEntity.Type.CHEST).dispenseSilently(pointer, stack));
+    }
+}

--- a/src/main/java/carpetextra/mixins/DispenserBehaviorGlowstoneMixin.java
+++ b/src/main/java/carpetextra/mixins/DispenserBehaviorGlowstoneMixin.java
@@ -1,0 +1,29 @@
+package carpetextra.mixins;
+
+import carpetextra.helpers.CarpetDispenserBehaviours;
+import carpetextra.utils.PlaceBlockDispenserBehavior;
+import net.minecraft.entity.vehicle.AbstractMinecartEntity;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPointer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(targets = "net/minecraft/block/dispenser/DispenserBehavior$18")
+public abstract class DispenserBehaviorGlowstoneMixin
+{
+    @SuppressWarnings("UnresolvedMixinReference")
+    @Inject(
+            method = "dispenseSilently(Lnet/minecraft/util/math/BlockPointer;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;",
+            at = @At(value = "INVOKE", shift = At.Shift.BEFORE,
+                    target = "Lnet/minecraft/block/dispenser/FallibleItemDispenserBehavior;dispenseSilently(Lnet/minecraft/util/math/BlockPointer;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;"),
+            cancellable = true
+    )
+    private void handleBlockPlacing(BlockPointer pointer, ItemStack stack, CallbackInfoReturnable<ItemStack> cir)
+    {
+        if (stack.getItem() instanceof BlockItem && PlaceBlockDispenserBehavior.canPlace(((BlockItem) stack.getItem()).getBlock()))
+            cir.setReturnValue(PlaceBlockDispenserBehavior.getInstance().dispenseSilently(pointer, stack));
+    }
+}

--- a/src/main/java/carpetextra/mixins/DispenserBlockMixin.java
+++ b/src/main/java/carpetextra/mixins/DispenserBlockMixin.java
@@ -39,9 +39,6 @@ public abstract class DispenserBlockMixin
         
         if (CarpetExtraSettings.dispensersFillMinecarts)
         {
-            if (item == Items.CHEST)
-                cir.setReturnValue(new MinecartDispenserBehaviour(AbstractMinecartEntity.Type.CHEST));
-
             if (item == Items.HOPPER)
                 cir.setReturnValue(new MinecartDispenserBehaviour(AbstractMinecartEntity.Type.HOPPER));
 
@@ -61,7 +58,7 @@ public abstract class DispenserBlockMixin
         if (CarpetExtraSettings.dispensersTillSoil && item instanceof HoeItem)
             cir.setReturnValue(new TillSoilDispenserBehaviour());
 
-        if (CarpetExtraSettings.dispensersFeedAnimals &&  FeedableItems.ITEMS.contains(item.asItem()))
+        if (CarpetExtraSettings.dispensersFeedAnimals && FeedableItems.ITEMS.contains(item.asItem()))
             cir.setReturnValue(new FeedAnimalDispenserBehaviour());
         
         if (CarpetExtraSettings.dragonsBreathConvertsCobbleToEndstone && item == Items.DRAGON_BREATH)

--- a/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
+++ b/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
@@ -12,6 +12,7 @@ import net.minecraft.block.StairsBlock;
 import net.minecraft.block.TurtleEggBlock;
 import net.minecraft.block.SeagrassBlock;
 import net.minecraft.block.KelpBlock;
+import net.minecraft.block.CoralParentBlock;
 import net.minecraft.block.dispenser.ItemDispenserBehavior;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.enums.BlockHalf;
@@ -157,6 +158,6 @@ public class PlaceBlockDispenserBehavior  extends ItemDispenserBehavior {
 
     private static boolean usePlacementContext(Item item, Block block) {
         return item.getClass() != BlockItem.class || block instanceof SeaPickleBlock || block instanceof TurtleEggBlock ||
-               block instanceof SeagrassBlock || block instanceof KelpBlock;
+               block instanceof SeagrassBlock || block instanceof KelpBlock || block instanceof CoralParentBlock;
     }
 }

--- a/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
+++ b/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
@@ -10,6 +10,8 @@ import net.minecraft.block.ObserverBlock;
 import net.minecraft.block.SeaPickleBlock;
 import net.minecraft.block.StairsBlock;
 import net.minecraft.block.TurtleEggBlock;
+import net.minecraft.block.SeagrassBlock;
+import net.minecraft.block.KelpBlock;
 import net.minecraft.block.dispenser.ItemDispenserBehavior;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.enums.BlockHalf;
@@ -71,7 +73,8 @@ public class PlaceBlockDispenserBehavior  extends ItemDispenserBehavior {
                     return new Direction[] {getPlayerLookDirection(), Direction.UP, Direction.DOWN, Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST};
                 }
             };
-            if (((BlockItem) item).place(ipc) == ActionResult.SUCCESS) {
+            ActionResult result = ((BlockItem) item).place(ipc);
+            if (result.isAccepted()) {
                 return itemStack;
             } else {
                 return super.dispenseSilently(blockPointer, itemStack);
@@ -120,6 +123,7 @@ public class PlaceBlockDispenserBehavior  extends ItemDispenserBehavior {
         FluidState currentFluidState = world.getFluidState(pos);
         if ((currentBlockState.isAir() || currentBlockState.getMaterial().isReplaceable()) && currentBlockState.getBlock() != block && state.canPlaceAt(world, pos)) {
             world.setBlockState(pos, state);
+            world.updateNeighbor(pos, state.getBlock(), pos);
             CompoundTag blockEntityTag = itemStack.getSubTag("BlockEntityTag");
             if (blockEntityTag != null && block instanceof BlockEntityProvider) {
                 BlockEntity be = world.getBlockEntity(pos);
@@ -152,6 +156,7 @@ public class PlaceBlockDispenserBehavior  extends ItemDispenserBehavior {
     }
 
     private static boolean usePlacementContext(Item item, Block block) {
-        return item.getClass() != BlockItem.class || block instanceof SeaPickleBlock || block instanceof TurtleEggBlock;
+        return item.getClass() != BlockItem.class || block instanceof SeaPickleBlock || block instanceof TurtleEggBlock ||
+               block instanceof SeagrassBlock || block instanceof KelpBlock;
     }
 }

--- a/src/main/resources/carpet-extra.mixins.json
+++ b/src/main/resources/carpet-extra.mixins.json
@@ -24,6 +24,11 @@
     "DropperBlock_craftingMixin",
     "DispenserBlockEntity_craftingMixin",
 
+    "DispenserBehaviorCarpetsMixin",
+    "DispenserBehaviorChestMixin",
+    "DispenserBehaviorFireChargeMixin",
+    "DispenserBehaviorGlowstoneMixin",
+
     "VillagerEntity_wartFarmMixin",
     "FarmerVillagerTask_wartFarmMixin",
     "VillagerTaskListProvider_wartFarmMixin",
@@ -41,7 +46,6 @@
     "BlocksMixin",
     "ChunkGeneratorMixin",
     "FallingBlockMixin",
-    "DispenserBehaviorFireChargeMixin",
     "ChickenEntityMixin",
     "LivingEntityMixin",
     "FlowerPotBlockMixin",


### PR DESCRIPTION
- Fixed items being placed and dispensed both at once (Two items where being used).
- Fixed chests, glowstone and carpets not being placed due to vanilla behavior conflicts.
- Fixed hoppers/chests/furnaces not being placed with `dispensersFillMinecarts` turned on.
- Fixed seagrass and kelp creating a water source when placed.
- Fixed blocks not updating when placed (Eg:Redstone lamps arent lit when next to a power source).