### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -1,0 +1,36 @@
+
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Pull Request Builds
+
+on:
+  pull_request:
+    paths:
+    - "src/**"
+
+jobs:
+  Build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Grant execute permission to gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: "Compiled artifacts for Pull Request #${{github.event.number}}"
+        path: build/libs

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -1,0 +1,35 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Development Builds
+
+on:
+  push:
+    paths:
+    - "src/**"
+
+jobs:
+  Build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+        restore-keys: ${{ runner.os }}-gradle
+    - name: Grant execute permission to gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Compiled artifacts for ${{ github.sha }}
+        path: build/libs

--- a/.github/workflows/rules-to-readme.yml
+++ b/.github/workflows/rules-to-readme.yml
@@ -77,7 +77,7 @@ jobs:
         continue-on-error: true
         run: |
           git add README.md
-          git config --global user.name 'github-actions[bot]' # Looks better than "github-actions-bot"
+          git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git commit -m "Update Readme for '${{ github.event.head_commit.message }}'"
           git push

--- a/.github/workflows/rules-to-readme.yml
+++ b/.github/workflows/rules-to-readme.yml
@@ -1,0 +1,83 @@
+
+name: Update Readme
+on:
+  push:
+    branches: 
+      - master
+    paths:
+    - "src/main/java/carpet/CarpetSettings.java"
+    - "README-header.md"
+jobs:
+  Rules:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Carpet extra sources
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Generate RulePrinter class
+        run: |
+          cd src/main/java/carpetextra/utils
+          echo "
+          package carpetextra.utils;
+          import carpetextra.CarpetExtraServer;
+          import carpet.CarpetServer;
+          import carpet.settings.SettingsManager;
+          import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+          import java.lang.System;
+          public class RulePrinter implements PreLaunchEntrypoint {
+            @Override
+            public void onPreLaunch() {
+                CarpetExtraServer.noop();
+                CarpetServer.onGameStarted();
+                CarpetServer.settingsManager.printAllRulesToLog(\"extras\");
+                System.exit(0);
+            }
+          }
+          " > RulePrinter.java
+          cd ../../../../../
+      - name: Replace fabric.mod.json
+        run: |
+          cd src/main/resources
+          rm fabric.mod.json
+          echo '
+          {
+            "schemaVersion": 1,
+            "id": "carpetextra",
+            "version": "1.4.11",
+            "entrypoints": {
+              "preLaunch": [ "carpetextra.utils.RulePrinter" ]
+            }
+           }' > fabric.mod.json
+          cd ../../../
+      - name: Run solution
+        run: |
+          chmod +x gradlew
+          ./gradlew runServer > settings-toProccess.txt
+      - name: Proccess Gradle log into a pretty readme page
+        run: |
+          cat README-header.md > README.md
+          from1="# Carpet Mod Settings";
+          File=settings-toProccess.txt
+          if grep -q "Deprecated Gradle features" "$File"; then # Happens after update to Gradle 6
+            to2="Deprecated Gradle features";
+          else
+            to2="BUILD SUCCESSFUL"
+          fi
+          a="$(cat settings-toProccess.txt)";a="$(echo "${a#*"$from1"}")"; echo "${a%%"$to2"*}" >> README.md
+      - name: Commit updated Readme page
+        continue-on-error: true
+        run: |
+          git add README.md
+          git config --global user.name 'github-actions[bot]' # Looks better than "github-actions-bot"
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -m "Update Readme for '${{ github.event.head_commit.message }}'"
+          git push

--- a/.github/workflows/rules-to-readme.yml
+++ b/.github/workflows/rules-to-readme.yml
@@ -5,7 +5,7 @@ on:
     branches: 
       - master
     paths:
-    - "src/main/java/carpet/CarpetSettings.java"
+    - "src/main/java/carpetextra/CarpetExtraSettings.java"
     - "README-header.md"
 jobs:
   Rules:

--- a/README-header.md
+++ b/README-header.md
@@ -1,0 +1,8 @@
+# carpet-extra
+Extra Features for Carpet Mod
+
+Use along side base [fabric-carpet](/gnembon/fabric-carpet) mod for the same minecraft version.
+
+Due to how autoCraftingTable feature is implemented, it has been moved to [a standalone extension](/gnembon/carpet-autoCraftingTable).
+
+# Carpet Extra Features

--- a/README-header.md
+++ b/README-header.md
@@ -1,8 +1,8 @@
 # carpet-extra
-Extra Features for Carpet Mod
+Extra Features for Carpet Mod.
 
-Use along side base [fabric-carpet](/gnembon/fabric-carpet) mod for the same minecraft version.
+Use along side base [fabric-carpet](https://github.com/gnembon/fabric-carpet) mod for the same minecraft version.
 
-Due to how autoCraftingTable feature is implemented, it has been moved to [a standalone extension](/gnembon/carpet-autoCraftingTable).
+Due to how autoCraftingTable feature is implemented, it has been moved to [a standalone extension](https://github.com/gnembon/carpet-autoCraftingTable).
 
 # Carpet Extra Features


### PR DESCRIPTION
Following gnembon/fabric-carpet#496, here comes the equivalent for carpet-extra!
Except for the different action (rules to readme vs rules to wiki), the body of this PR is mostly a copy-paste of the other one.

For anyone reviewing who doesn't know what Actions are (from gnembon/fabric-carpet#496):
GitHub Actions are a GitHub feature that allow you to configure automated workflows to run on their servers when specified events occur.
Those are completely free for open source/public repositories.
They store the logs of everything running in them, and support uploading artifacts from them.

### What actions does this PR add
This PR includes three Actions. This time the Actions page of the repo at [altrisi/carpet-extra/actions](https://github.com/altrisi/carpet-extra/actions) isn't too populated, but you can look at it anyway as a preview (in some actions, only last run contains latest changes).
The included actions are the following:
#### Build on push (Development Builds)
As the name says, every time you push to the repo (including merging PRs/etc), it will build Carpet Extra and store artifacts for anyone (registered to GitHub) to download as a development build.
This action and build on PR will only run when changes in the `src` directory are being made.

[Preview](https://github.com/altrisi/carpet-extra/actions?query=workflow%3A%22Development+Builds%22)

#### Build on PR
Builds the content of a PR and tells you if it does actually build. It also uploads build artifacts so you (or anyone) can quickly test the changes.
Useful in order not to get any surprise when merging code where the PR author may have forgotten to add an import or any other typo that prevents things from building.
If it can't build it, it will show `All checks have failed` above the merge button in red to notify that, and will also show crosses on the commits where it failed (green checks where it didn't or nothing if didn't even run).

#### Rules to readme
This one is the one that is different from fabric-carpet.

Since carpet-extra instead of using a wiki page to show the rules uses the README file, the action had to be changed.
It also needed some changes since it had some "conflicts" with Gradle 6, which is the Gradle version used in carpet-extra but not in fabric-carpet.

However, there aren't that many changes from the original one. The first change was made to the RulePrinter. Since we run it ASAP, neither Carpet or Extra are initialized, so we have to initialize the extension manually. We also filter rules by category to `extras`. Then we replace the fabric.mod.json like in the other one, just with a different id to prevent conflicting with carpet and with another name.
RulePrinter basically added 2 lines and changed to 
```java
  package carpetextra.utils;

  import carpetextra.CarpetExtraServer;
  import carpet.CarpetServer;
  import carpet.settings.SettingsManager;
  import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
  import java.lang.System;

  public class RulePrinter implements PreLaunchEntrypoint {
    @Override
    public void onPreLaunch() {
        CarpetExtraServer.noop();
        CarpetServer.onGameStarted();
        CarpetServer.settingsManager.printAllRulesToLog("extras");
        System.exit(0);
    }
  }
```

Since in carpet-extra Gradle 6 is used, it seems that some Gradle tasks use deprecated features, that Gradle warns, of course, right above our `BUILD SUCCESSFUL` message, so it would be included in the Readme if we would use the fabric-carpet script directly. Therefore, if that message is included (only in that case, since, if those tasks were updated, the message wouldn't appear anymore and bad things could happen), we change the `BUILD SUCCESSFUL` check to `Deprecated Gradle features` (I should PR that to fabric-carpet too to make it future-proof). We also remove the `Carpet Mod Settings` default header since we are in Extra now.

Since we are updating a readme, we can't just dump the rules straight there, so a new file is included, **README-header.md**, which is printed by the action _before_ the rules, in order to be able to add _extra_ text there. The action is prepared to update the readme when either the CarpetExtraSettings file or the header is modified.

You can preview it [here](https://github.com/altrisi/carpet-extra/tree/altrisi-rules-tests-rc4).

### Misc changes

- The readme header was updated to reflect that the autoCraftingTable is currently in a separate extension.
- `fabric-carpet` was hyperlinked in the readme.
- Also, a dot was added to the first line.

### What else can you do with Actions?
Well, as I already said in gnembon/fabric-carpet#496, you can do basically anything, as long as you code it.
[]

### Why should I add them here?
Well, do it for the dot in the first line. He really wants to be there

And 4 da cool badges

![Development Builds](https://github.com/altrisi/carpet-extra/workflows/Development%20Builds/badge.svg)
```markdown
![Development Builds](https://github.com/gnembon/carpet-extra/workflows/Development%20Builds/badge.svg)
```

### Notes
After merging this PR, I think Rules to readme should launch automatically, since the header will have changed (depending on update order probably) (which isn't bad, since readme needs an update anyway).