### PR TITLE
dispenserPlacesBlocks fixes

### DIFF
--- a/src/main/java/carpetextra/mixins/DispenserBehaviorCarvedPumpkinMixin.java
+++ b/src/main/java/carpetextra/mixins/DispenserBehaviorCarvedPumpkinMixin.java
@@ -1,0 +1,30 @@
+package carpetextra.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import carpetextra.utils.PlaceBlockDispenserBehavior;
+import net.minecraft.block.dispenser.FallibleItemDispenserBehavior;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPointer;
+
+@Mixin(targets = "net/minecraft/block/dispenser/DispenserBehavior$16")
+public abstract class DispenserBehaviorCarvedPumpkinMixin extends FallibleItemDispenserBehavior {
+    @SuppressWarnings("UnresolvedMixinReference")
+    @Inject(
+            method = "dispenseSilently(Lnet/minecraft/util/math/BlockPointer;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;",
+            at = @At("RETURN"),
+            cancellable = true
+    )
+    private void handleBlockPlacing(BlockPointer pointer, ItemStack stack, CallbackInfoReturnable<ItemStack> cir)
+    {
+        if (!this.isSuccess() && stack.getItem() instanceof BlockItem && PlaceBlockDispenserBehavior.canPlace(((BlockItem) stack.getItem()).getBlock()))
+        {
+            this.setSuccess(true);
+            cir.setReturnValue(PlaceBlockDispenserBehavior.getInstance().dispenseSilently(pointer, stack));
+        }
+    }
+}

--- a/src/main/java/carpetextra/mixins/DispenserBehaviorMobHeadMixin.java
+++ b/src/main/java/carpetextra/mixins/DispenserBehaviorMobHeadMixin.java
@@ -1,0 +1,30 @@
+package carpetextra.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import carpetextra.utils.PlaceBlockDispenserBehavior;
+import net.minecraft.block.dispenser.FallibleItemDispenserBehavior;
+import net.minecraft.item.BlockItem;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPointer;
+
+@Mixin(targets = {"net/minecraft/block/dispenser/DispenserBehavior$14", "net/minecraft/block/dispenser/DispenserBehavior$15"})
+public abstract class DispenserBehaviorMobHeadMixin extends FallibleItemDispenserBehavior {
+    @SuppressWarnings("UnresolvedMixinReference")
+    @Inject(
+            method = "dispenseSilently(Lnet/minecraft/util/math/BlockPointer;Lnet/minecraft/item/ItemStack;)Lnet/minecraft/item/ItemStack;",
+            at = @At("RETURN"),
+            cancellable = true
+    )
+    private void handleBlockPlacing(BlockPointer pointer, ItemStack stack, CallbackInfoReturnable<ItemStack> cir)
+    {
+        if (!this.isSuccess() && stack.getItem() instanceof BlockItem && PlaceBlockDispenserBehavior.canPlace(((BlockItem) stack.getItem()).getBlock()))
+        {
+            this.setSuccess(true);
+            cir.setReturnValue(PlaceBlockDispenserBehavior.getInstance().dispenseSilently(pointer, stack));
+        }
+    }
+}

--- a/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
+++ b/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
@@ -128,7 +128,7 @@ public class PlaceBlockDispenserBehavior  extends ItemDispenserBehavior {
         BlockState currentBlockState = world.getBlockState(pos);
         FluidState currentFluidState = world.getFluidState(pos);
         if ((currentBlockState.isAir() || currentBlockState.getMaterial().isReplaceable()) && currentBlockState.getBlock() != block && state.canPlaceAt(world, pos)) {
-            world.setBlockState(pos, state);
+            boolean blockWasPlaced = world.setBlockState(pos, state);
             world.updateNeighbor(pos, state.getBlock(), pos);
             CompoundTag blockEntityTag = itemStack.getSubTag("BlockEntityTag");
             if (blockEntityTag != null && block instanceof BlockEntityProvider) {
@@ -144,7 +144,7 @@ public class PlaceBlockDispenserBehavior  extends ItemDispenserBehavior {
             }
             BlockSoundGroup soundType = state.getSoundGroup();
             world.playSound(null, pos, soundType.getPlaceSound(), SoundCategory.BLOCKS, (soundType.getVolume() + 1.0F / 2.0F), soundType.getPitch() * 0.8F);
-            if (!world.getBlockState(pos).isAir()) {
+            if (blockWasPlaced) {
                 itemStack.decrement(1);
                 return itemStack;
             }

--- a/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
+++ b/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
@@ -123,11 +123,10 @@ public class PlaceBlockDispenserBehavior  extends ItemDispenserBehavior {
             state = state.with(Properties.PERSISTENT, true);
         }
 
-        state = Block.postProcessState(state, world, pos);
-
         BlockState currentBlockState = world.getBlockState(pos);
         FluidState currentFluidState = world.getFluidState(pos);
         if ((currentBlockState.isAir() || currentBlockState.getMaterial().isReplaceable()) && currentBlockState.getBlock() != block && state.canPlaceAt(world, pos)) {
+            state = Block.postProcessState(state, world, pos);
             boolean blockWasPlaced = world.setBlockState(pos, state);
             world.updateNeighbor(pos, state.getBlock(), pos);
             CompoundTag blockEntityTag = itemStack.getSubTag("BlockEntityTag");

--- a/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
+++ b/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
@@ -128,6 +128,7 @@ public class PlaceBlockDispenserBehavior  extends ItemDispenserBehavior {
         if ((currentBlockState.isAir() || currentBlockState.getMaterial().isReplaceable()) && currentBlockState.getBlock() != block && state.canPlaceAt(world, pos)) {
             state = Block.postProcessState(state, world, pos);
             boolean blockWasPlaced = world.setBlockState(pos, state);
+            block.onPlaced(world, pos, state, null, itemStack);
             world.updateNeighbor(pos, state.getBlock(), pos);
             CompoundTag blockEntityTag = itemStack.getSubTag("BlockEntityTag");
             if (blockEntityTag != null && block instanceof BlockEntityProvider) {

--- a/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
+++ b/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
@@ -6,6 +6,7 @@ import net.minecraft.block.BlockEntityProvider;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.DispenserBlock;
 import net.minecraft.block.FluidFillable;
+import net.minecraft.block.LeavesBlock;
 import net.minecraft.block.ObserverBlock;
 import net.minecraft.block.SeaPickleBlock;
 import net.minecraft.block.StairsBlock;
@@ -116,6 +117,10 @@ public class PlaceBlockDispenserBehavior  extends ItemDispenserBehavior {
 
         if (block instanceof ObserverBlock) {
             state = state.with(ObserverBlock.POWERED, true);
+        }
+
+        if (block instanceof LeavesBlock) {
+            state = state.with(Properties.PERSISTENT, true);
         }
 
         state = Block.postProcessState(state, world, pos);

--- a/src/main/resources/carpet-extra.mixins.json
+++ b/src/main/resources/carpet-extra.mixins.json
@@ -31,6 +31,7 @@
     "DispenserBehaviorGlowstoneMixin",
     "DispenserBehaviorShearsMixin",
     "DispenserBehaviorCarvedPumpkinMixin",
+    "DispenserBehaviorMobHeadMixin",
 
     "VillagerEntity_wartFarmMixin",
     "FarmerVillagerTask_wartFarmMixin",

--- a/src/main/resources/carpet-extra.mixins.json
+++ b/src/main/resources/carpet-extra.mixins.json
@@ -30,6 +30,7 @@
     "DispenserBehaviorFireChargeMixin",
     "DispenserBehaviorGlowstoneMixin",
     "DispenserBehaviorShearsMixin",
+    "DispenserBehaviorCarvedPumpkinMixin",
 
     "VillagerEntity_wartFarmMixin",
     "FarmerVillagerTask_wartFarmMixin",


### PR DESCRIPTION
closes #102 
* Fixed leaves placed by a dispenser not having blocks state persistent=true
* Fixed carved pumpkins not being able to be placed
* Fixed Jack O'Lantern item being dispensed after summoning snow/iron golem
* Fixed saplings playing stone sound for invalid placement
* Fixed mob heads not being able to be placed
* Fixed named tile entities losing their name when being placed
