### PR TITLE
Renamed dispenserPlacesBlocks to dispensersPlaceBlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Disables player entity collision.
 * Required options: `true`, `false`  
 * Categories: `EXTRAS`, `CREATIVE`, `EXPERIMENTAL`  
   
-## dispenserPlacesBlocks
+## dispensersPlaceBlocks
 Dispensers can place blocks.  
 * Type: `boolean`  
 * Default value: `false`  

--- a/src/main/java/carpetextra/CarpetExtraSettings.java
+++ b/src/main/java/carpetextra/CarpetExtraSettings.java
@@ -66,7 +66,7 @@ public class CarpetExtraSettings
     public static boolean autoCraftingDropper = false;
 
     @Rule(desc = "Dispensers can place blocks.", category = {CREATIVE, EXTRA, DISPENSER})
-    public static boolean dispenserPlacesBlocks = false;
+    public static boolean dispensersPlaceBlocks = false;
 
     @Rule(
             desc = "Variable delays on wooden components (buttons, pressure plates).",

--- a/src/main/java/carpetextra/mixins/DispenserBlockMixin.java
+++ b/src/main/java/carpetextra/mixins/DispenserBlockMixin.java
@@ -26,7 +26,7 @@ public abstract class DispenserBlockMixin
     private void getBehaviorForItem(ItemStack itemStack_1, CallbackInfoReturnable<DispenserBehavior> cir)
     {
         Item item = itemStack_1.getItem();
-        if (CarpetExtraSettings.dispenserPlacesBlocks && !BEHAVIORS.containsKey(item) && item instanceof BlockItem)
+        if (CarpetExtraSettings.dispensersPlaceBlocks && !BEHAVIORS.containsKey(item) && item instanceof BlockItem)
         {
             if (PlaceBlockDispenserBehavior.canPlace(((BlockItem) item).getBlock()))
             {

--- a/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
+++ b/src/main/java/carpetextra/utils/PlaceBlockDispenserBehavior.java
@@ -45,7 +45,7 @@ public class PlaceBlockDispenserBehavior  extends ItemDispenserBehavior {
     @Override
     public ItemStack dispenseSilently(BlockPointer blockPointer, ItemStack itemStack) {
         Item item = itemStack.getItem();
-        if (!CarpetExtraSettings.dispenserPlacesBlocks || !(item instanceof BlockItem)) {
+        if (!CarpetExtraSettings.dispensersPlaceBlocks || !(item instanceof BlockItem)) {
             return super.dispenseSilently(blockPointer, itemStack);
         }
         Block block = ((BlockItem) item).getBlock();
@@ -154,7 +154,7 @@ public class PlaceBlockDispenserBehavior  extends ItemDispenserBehavior {
     }
 
     public static boolean canPlace(Block block) {
-        if (CarpetExtraSettings.dispenserPlacesBlocks) {
+        if (CarpetExtraSettings.dispensersPlaceBlocks) {
             // extra exceptions
             return true;
         }


### PR DESCRIPTION
Renamed `dispenserPlacesBlocks` to `dispensersPlaceBlocks` for consistency with other dispenser rules