### PR TITLE
Made all injections in scaffolding-related mixins not required.

### DIFF
--- a/src/main/java/carpetextra/mixins/ScaffoldingBlock_scaffoldingDistanceMixin.java
+++ b/src/main/java/carpetextra/mixins/ScaffoldingBlock_scaffoldingDistanceMixin.java
@@ -22,19 +22,19 @@ public class ScaffoldingBlock_scaffoldingDistanceMixin {
     }
      */
 
-    @ModifyConstant(method = "scheduledTick", constant = @Constant(intValue = 7))
+    @ModifyConstant(method = "scheduledTick", constant = @Constant(intValue = 7), require = 0)
     private int scheduledTick_maxDistance(int oldValue)
     {
         return CarpetExtraSettings.scaffoldingDistance;
     }
 
-    @ModifyConstant(method = "canPlaceAt", constant = @Constant(intValue = 7))
+    @ModifyConstant(method = "canPlaceAt", constant = @Constant(intValue = 7), require = 0)
     private int canPlaceAt_maxDistance(int oldValue)
     {
         return CarpetExtraSettings.scaffoldingDistance;
     }
 
-    @ModifyConstant(method = "calculateDistance", constant = @Constant(intValue = 7))
+    @ModifyConstant(method = "calculateDistance", constant = @Constant(intValue = 7), require = 0)
     private static int calculateDistance_maxDistance(int oldValue)
     {
         return CarpetExtraSettings.scaffoldingDistance;

--- a/src/main/java/carpetextra/mixins/ScaffoldingItem_scaffoldingDistanceMixin.java
+++ b/src/main/java/carpetextra/mixins/ScaffoldingItem_scaffoldingDistanceMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 @Mixin(ScaffoldingItem.class)
 public class ScaffoldingItem_scaffoldingDistanceMixin {
-    @ModifyConstant(method = "getPlacementContext", constant = @Constant(intValue = 7))
+    @ModifyConstant(method = "getPlacementContext", constant = @Constant(intValue = 7), require = 0)
     private static int getPlacementContext_maxDistance(int oldValue)
     {
         return CarpetExtraSettings.scaffoldingDistance;


### PR DESCRIPTION
This makes carpet-extra compatible with other mods that modify the scaffolding limit such as [scaffolding_extension]( https://gitlab.com/supersaiyansubtlety/scaffolding_extension).