### PR TITLE
Added lily pad to betterBonemeal

### DIFF
--- a/src/main/java/carpetextra/CarpetExtraSettings.java
+++ b/src/main/java/carpetextra/CarpetExtraSettings.java
@@ -306,7 +306,7 @@ public class CarpetExtraSettings
     public static boolean enderPearlChunkLoading = false;
 
     @Rule(
-            desc = "Bonemeal can be used to grow sugarcane and cactus.",
+            desc = "Bonemeal can be used to grow sugarcane, cactus and lily pads.",
             category = {FEATURE, EXTRA, SURVIVAL}
     )
     public static boolean betterBonemeal = false;

--- a/src/main/java/carpetextra/mixins/LilyPadBlock_fertilizerMixin.java
+++ b/src/main/java/carpetextra/mixins/LilyPadBlock_fertilizerMixin.java
@@ -1,0 +1,59 @@
+package carpetextra.mixins;
+
+import carpetextra.CarpetExtraSettings;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.Fertilizable;
+import net.minecraft.block.LilyPadBlock;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockView;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.Random;
+
+@Mixin(LilyPadBlock.class)
+public abstract class LilyPadBlock_fertilizerMixin implements Fertilizable {
+    @Shadow protected abstract boolean canPlantOnTop(BlockState floor, BlockView world, BlockPos pos);
+
+    @Override
+    public boolean isFertilizable(BlockView world, BlockPos pos, BlockState state, boolean isClient) {
+        return CarpetExtraSettings.betterBonemeal;
+    }
+
+    @Override
+    public boolean canGrow(World world, Random random, BlockPos pos, BlockState state)
+    {
+        return true;
+    }
+
+    @Override
+    public void grow(ServerWorld world, Random random, BlockPos pos, BlockState state)
+    {
+        if(!CarpetExtraSettings.betterBonemeal) return;
+        BlockState blockState = Blocks.LILY_PAD.getDefaultState();
+
+        label:
+        for(int i = 0; i < 24; ++i) {
+            BlockPos growPos = pos;
+            for (int j = 0; j < i / 16; ++j) {
+                growPos = growPos.add(random.nextInt(3) - 1, 0, random.nextInt(3) - 1);
+                if (world.getBlockState(growPos).isFullCube(world, growPos)) {
+                    continue label;
+                }
+            }
+            if (canGrowTo(growPos,world)) {
+                world.setBlockState(growPos,blockState);
+                state.scheduledTick(world, growPos, random);
+            }
+
+        }
+
+    }
+
+    private boolean canGrowTo(BlockPos pos, BlockView world) {
+        return this.canPlantOnTop(world.getBlockState(pos.down()), world, pos.down()) && world.getBlockState(pos).isAir();
+    }
+}

--- a/src/main/java/carpetextra/mixins/LilyPadBlock_fertilizerMixin.java
+++ b/src/main/java/carpetextra/mixins/LilyPadBlock_fertilizerMixin.java
@@ -35,13 +35,13 @@ public abstract class LilyPadBlock_fertilizerMixin implements Fertilizable {
         if(!CarpetExtraSettings.betterBonemeal) return;
         BlockState blockState = Blocks.LILY_PAD.getDefaultState();
 
-        label:
+        stopGrowth:
         for(int i = 0; i < 24; ++i) {
             BlockPos growPos = pos;
             for (int j = 0; j < i / 16; ++j) {
                 growPos = growPos.add(random.nextInt(3) - 1, 0, random.nextInt(3) - 1);
                 if (world.getBlockState(growPos).isFullCube(world, growPos)) {
-                    continue label;
+                    continue stopGrowth;
                 }
             }
             if (canGrowTo(growPos,world)) {

--- a/src/main/resources/carpet-extra.mixins.json
+++ b/src/main/resources/carpet-extra.mixins.json
@@ -69,6 +69,7 @@
     "ScaffoldingItem_scaffoldingDistanceMixin",
     "SugarCaneBlock_fertilizerMixin",
     "CactusBlock_fertilizerMixin",
+    "LilyPadBlock_fertilizerMixin",
 
     "MinecraftServer_updateSuppressionCrashFixMixin",
     "World_updateSuppressionCrashFixMixin"


### PR DESCRIPTION
Closes #198 

Bonemeal applied to lily pads makes them spread in a similar way to seagrass when using bonemeal underwater.
Here are some samples of a single bonemeal used on the centere lilypad:

![Lily pad bonemealed](https://user-images.githubusercontent.com/40722305/114589147-ae140e00-9c87-11eb-8222-9cf00279e2bd.png)

Not sure if the amount is balanced or not, i had a look at how much bonemeal is returned if the farmed lily pads were composted, and it returned around half the bonemeal spent. I also made a version where it chooses a random available horizontal direction and only grows a single lily pad. If that's prefered i could swap that out.