### PR TITLE
Accurate Block Placement: Remove the vanilla position check added in 1.18.2

### DIFF
--- a/src/main/java/carpetextra/mixins/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/carpetextra/mixins/ServerPlayNetworkHandlerMixin.java
@@ -1,0 +1,25 @@
+package carpetextra.mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.util.math.Vec3d;
+import carpetextra.CarpetExtraSettings;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public abstract class ServerPlayNetworkHandlerMixin
+{
+    @Redirect(method = "onPlayerInteractBlock",
+              at = @At(value = "INVOKE",
+                       target = "Lnet/minecraft/util/math/Vec3d;subtract(Lnet/minecraft/util/math/Vec3d;)Lnet/minecraft/util/math/Vec3d;"))
+    private Vec3d carpetextra_removeHitPosCheck(Vec3d hitVec, Vec3d blockCenter)
+    {
+        if (CarpetExtraSettings.accurateBlockPlacement)
+        {
+            return Vec3d.ZERO;
+        }
+
+        return hitVec.subtract(blockCenter);
+    }
+}

--- a/src/main/resources/carpet-extra.mixins.json
+++ b/src/main/resources/carpet-extra.mixins.json
@@ -16,6 +16,7 @@
     "AbstractButtonBlock_variableWoodMixin",
     "ItemFrameEntity_comparatorReadsClockMixin",
     "ItemStackMixin",
+    "ServerPlayNetworkHandlerMixin",
     "ThrownEntityMixin",
     "BlockItemMixin_accurateBlockPlacement",
     "HopperMinecartEntity_cooldownFixMixin",


### PR DESCRIPTION
This fixes the `accurateBlockPlacement` protocol being broken in 1.18.2+ and the item use packets trying to use the protocol just spamming warnings in the server console and creating ghost blocks.