### PR TITLE
New Rule: `fallingBlockDispensers`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,6 @@ repositories {
 	}
 }
 
-runClient.doFirst {
-	args = ['--username', "Player${new Random().nextInt(1000)}", '--uuid', UUID.randomUUID()]
-}
-
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,10 @@ repositories {
 	}
 }
 
+runClient.doFirst {
+	args = ['--username', "Player${new Random().nextInt(1000)}", '--uuid', UUID.randomUUID()]
+}
+
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 

--- a/src/main/java/carpetextra/CarpetExtraSettings.java
+++ b/src/main/java/carpetextra/CarpetExtraSettings.java
@@ -349,4 +349,11 @@ public class CarpetExtraSettings
             category = {EXTRA, FEATURE, DISPENSER}
     )
     public static boolean dispensersPotPlants = false;
+
+    @Rule(
+            desc = "Dispensers/Droppers with a block in front of them when powered will turn that block into a falling block",
+            extra = "dispenser & dropper give the same velocity to the falling block like they do in 22w13oneblockatatime",
+            category = {EXTRA, FEATURE, DISPENSER}
+    )
+    public static boolean fallingBlockDispensers = false;
 }

--- a/src/main/java/carpetextra/mixins/DispenserBlock_fallingBlockMixin.java
+++ b/src/main/java/carpetextra/mixins/DispenserBlock_fallingBlockMixin.java
@@ -12,8 +12,8 @@ import net.minecraft.state.property.Properties;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.random.AbstractRandom;
 import net.minecraft.world.World;
-import net.minecraft.world.gen.random.AbstractRandom;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -44,7 +44,7 @@ public class DispenserBlock_fallingBlockMixin {
 
     @Inject(
             method = "scheduledTick(Lnet/minecraft/block/BlockState;Lnet/minecraft/server/world/ServerWorld;" +
-                    "Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/world/gen/random/AbstractRandom;)V",
+                    "Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/math/random/AbstractRandom;)V",
             at = @At("HEAD"),
             cancellable = true
     )

--- a/src/main/java/carpetextra/mixins/DispenserBlock_fallingBlockMixin.java
+++ b/src/main/java/carpetextra/mixins/DispenserBlock_fallingBlockMixin.java
@@ -1,0 +1,63 @@
+package carpetextra.mixins;
+
+import carpetextra.CarpetExtraSettings;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.DispenserBlock;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.FallingBlockEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.state.property.Properties;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import net.minecraft.world.gen.random.AbstractRandom;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(DispenserBlock.class)
+public class DispenserBlock_fallingBlockMixin {
+
+    // This is what happens to the code when a constructor is private and I just want to change the velocity before spawnEntity xD
+
+    private static final Vec3d INITIAL_VELOCITY = new Vec3d(0.0, 0.1, 0.0);
+
+    private void createFallingBlockWithVelocity(World world, BlockPos pos, BlockState state, Vec3d velocity) {
+        FallingBlockEntity fallingBlockEntity = new FallingBlockEntity(EntityType.FALLING_BLOCK, world);
+        FallingBlockEntityAccessor fallingBlockAccessor = (FallingBlockEntityAccessor)fallingBlockEntity;
+        fallingBlockAccessor.setBlock(state.contains(Properties.WATERLOGGED) ? state.with(Properties.WATERLOGGED, false) : state);
+        fallingBlockEntity.intersectionChecked = true;
+        Vec3d vecPos = Vec3d.ofBottomCenter(pos);
+        fallingBlockEntity.setPosition(vecPos);
+        fallingBlockEntity.setVelocity(velocity);
+        fallingBlockEntity.prevX = vecPos.x;
+        fallingBlockEntity.prevY = vecPos.y;
+        fallingBlockEntity.prevZ = vecPos.z;
+        fallingBlockEntity.setFallingBlockPos(fallingBlockEntity.getBlockPos());
+        world.setBlockState(pos, state.getFluidState().getBlockState(), Block.NOTIFY_ALL);
+        world.spawnEntity(fallingBlockEntity);
+    }
+
+    @Inject(
+            method = "scheduledTick(Lnet/minecraft/block/BlockState;Lnet/minecraft/server/world/ServerWorld;" +
+                    "Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/world/gen/random/AbstractRandom;)V",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    public void onScheduledTick(BlockState state, ServerWorld world, BlockPos pos, AbstractRandom rand, CallbackInfo ci) {
+        if (CarpetExtraSettings.fallingBlockDispensers) {
+            Direction direction = state.get(DispenserBlock.FACING);
+            BlockPos facingPos = pos.offset(direction);
+            BlockState facingState = world.getBlockState(facingPos);
+            if (!facingState.isAir() && (!facingState.isOf(Blocks.WATER) && !facingState.isOf(Blocks.LAVA) || facingState.getFluidState().isStill())) {
+                Vec3d velocity = (state.isOf(Blocks.DROPPER) ? INITIAL_VELOCITY : INITIAL_VELOCITY.add(Vec3d.of((direction).getVector())));
+                createFallingBlockWithVelocity(world, facingPos, facingState, velocity);
+                ci.cancel();
+            }
+        }
+    }
+}

--- a/src/main/java/carpetextra/mixins/FallingBlockEntityAccessor.java
+++ b/src/main/java/carpetextra/mixins/FallingBlockEntityAccessor.java
@@ -1,0 +1,12 @@
+package carpetextra.mixins;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.FallingBlockEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(FallingBlockEntity.class)
+public interface FallingBlockEntityAccessor {
+    @Accessor
+    void setBlock(BlockState state);
+}

--- a/src/main/resources/carpet-extra.mixins.json
+++ b/src/main/resources/carpet-extra.mixins.json
@@ -67,7 +67,9 @@
     "ScaffoldingItem_scaffoldingDistanceMixin",
     "SugarCaneBlock_fertilizerMixin",
     "CactusBlock_fertilizerMixin",
-    "LilyPadBlock_fertilizerMixin"
+    "LilyPadBlock_fertilizerMixin",
+    "DispenserBlock_fallingBlockMixin",
+    "FallingBlockEntityAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Dispensers/Droppers with a block in front of them when powered will turn that block into a falling block.
Dispenser & Dropper give the same velocity to the falling blocks as they do in 22w13oneblockatatime

Using movable tile entities you can simulate there behaviour in 22w13oneblockatatime