### PR TITLE
Improve dispensersToggleThings Note block comparability with Fabrication

### DIFF
--- a/src/main/java/carpetextra/dispenser/behaviors/ToggleBlockDispenserBehavior.java
+++ b/src/main/java/carpetextra/dispenser/behaviors/ToggleBlockDispenserBehavior.java
@@ -2,6 +2,7 @@ package carpetextra.dispenser.behaviors;
 
 import java.util.Set;
 
+import carpetextra.fakes.FakePlayerEntity;
 import com.google.common.collect.Sets;
 
 import net.minecraft.block.Block;
@@ -19,6 +20,9 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 
 public class ToggleBlockDispenserBehavior extends FallibleItemDispenserBehavior {
+
+    private FakePlayerEntity fakePlayerEntity;
+
     public static Set<Block> TOGGLEABLE_BLOCKS = Sets.newHashSet(
         Blocks.OAK_BUTTON,
         Blocks.SPRUCE_BUTTON,
@@ -53,8 +57,12 @@ public class ToggleBlockDispenserBehavior extends FallibleItemDispenserBehavior 
         if(TOGGLEABLE_BLOCKS.contains(frontBlockState.getBlock())) {
             BlockHitResult hitResult = new BlockHitResult(Vec3d.of(frontBlockPos), dispenserFacing.getOpposite(), frontBlockPos, false);
 
+            // make fake player
+            if (fakePlayerEntity == null) fakePlayerEntity = new FakePlayerEntity(world, pointer.getPos());
+            fakePlayerEntity.setStackInHand(Hand.MAIN_HAND, stack);
+
             // try to use block
-            if(frontBlockState.onUse(world, null, Hand.MAIN_HAND, hitResult).isAccepted()) {
+            if(frontBlockState.onUse(world, fakePlayerEntity, Hand.MAIN_HAND, hitResult).isAccepted()) {
                 return stack;
             }
         }

--- a/src/main/java/carpetextra/fakes/FakePlayerEntity.java
+++ b/src/main/java/carpetextra/fakes/FakePlayerEntity.java
@@ -1,0 +1,28 @@
+package carpetextra.fakes;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import java.util.UUID;
+
+public class FakePlayerEntity extends PlayerEntity {
+    public static final UUID uuid = UUID.fromString("7fc6d34b-ed7e-4895-a451-8e120cefb201");
+    public static final String name = "CarpetExtraFakePlayer";
+    public static final GameProfile profile = new GameProfile(uuid, name);
+
+    public FakePlayerEntity(World world, BlockPos pos) {
+        super(world, pos, 0.0f, profile, null);
+    }
+
+    @Override
+    public boolean isSpectator() {
+        return false;
+    }
+
+    @Override
+    public boolean isCreative() {
+        return false;
+    }
+}


### PR DESCRIPTION
Fabrication has a few features that use the PlayerEntity from the onUse function. Specifically, "Exact note block tuning," which, if right clicked with a stack of sticks, sets the pitch of the note block to the size of the stack minus one. I thought this would work perfectly with dispensersToggleThings because it requires a stick to toggle things, but it would crash due to passing in a null for PlayerEntity.