### PR TITLE
Allow for any 1.20 version, as 1.20.1 is compatible

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
   "depends": {
     "fabricloader": ">=0.11.6",
     "carpet": ">=1.4.112",
-    "minecraft": "1.20",
+    "minecraft": "1.20.x",
     "java": ">=17"
   },
   "custom": {


### PR DESCRIPTION
Hopefully this does not cause any issues with 1.20.2




Should this instead be made to only include 1.20 and 1.20.1?