### PR TITLE
Improve compatibility of `dispensersToggleThings` by optionally using Fabric API's stub players

### DIFF
--- a/src/main/java/carpetextra/dispenser/behaviors/ToggleBlockDispenserBehavior.java
+++ b/src/main/java/carpetextra/dispenser/behaviors/ToggleBlockDispenserBehavior.java
@@ -2,6 +2,7 @@ package carpetextra.dispenser.behaviors;
 
 import java.util.Set;
 
+import carpetextra.helpers.PlayerForInteractions;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -52,7 +53,7 @@ public class ToggleBlockDispenserBehavior extends FallibleItemDispenserBehavior 
             BlockHitResult hitResult = new BlockHitResult(Vec3d.of(frontBlockPos), dispenserFacing.getOpposite(), frontBlockPos, false);
 
             // try to use block
-            if(frontBlockState.onUse(world, null, Hand.MAIN_HAND, hitResult).isAccepted()) {
+            if(frontBlockState.onUse(world, PlayerForInteractions.get(world), Hand.MAIN_HAND, hitResult).isAccepted()) {
                 return stack;
             }
         }

--- a/src/main/java/carpetextra/helpers/PlayerForInteractions.java
+++ b/src/main/java/carpetextra/helpers/PlayerForInteractions.java
@@ -1,0 +1,58 @@
+package carpetextra.helpers;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+import carpet.CarpetSettings;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+
+/**
+ * Hosts a method to get a {@link ServerPlayerEntity} to be used for interactions in a way that is more compatible
+ * with mods than just using {@code null}
+ */
+public class PlayerForInteractions {
+    /**
+     * Gets a player for interactions on the given world, or {@code null} if Fabric API isn't loaded.
+     * 
+     * @param world The world the player should be from
+     */
+    public static ServerPlayerEntity get(ServerWorld world) {
+        try {
+            return (ServerPlayerEntity)INVOKER.invokeExact(world);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+    /**
+     * Holds either a Direct* {@link MethodHandle} to Fabric API's FakePlayer.get(ServerWorld) method, or
+     * a constant {@link MethodHandle} that simply returns {@code null} if that API isn't available, which
+     * is good enough given we handle passing {@code null} to where vanilla would fail ourselves.<br>
+     * 
+     * * Not truly Direct given we need to adapt its return type to not use a type from them
+     */
+    private static final MethodHandle INVOKER; // setup at the end
+
+    static {
+        MethodHandle invoker = null;
+        if (FabricLoader.getInstance().isModLoaded("fabric-events-interaction-v0")) {
+            try {
+                Class<?> fakePlayerApi = Class.forName("net.fabricmc.fabric.api.entity.FakePlayer");
+                MethodHandle handle = MethodHandles.lookup().findStatic(fakePlayerApi, "get", MethodType.methodType(fakePlayerApi, ServerWorld.class));
+                // don't require their type to be used in calls
+                invoker = handle.asType(MethodType.methodType(ServerPlayerEntity.class, ServerWorld.class));
+            } catch (ReflectiveOperationException e) {
+                CarpetSettings.LOG.warn("Failed to obtain fake player for interactions with mods from Fabric API, using fallback!", e);
+            }
+            
+        } 
+        if (invoker == null) {
+            // Make a MethodHandle that returns null
+            INVOKER = MethodHandles.empty(MethodType.methodType(ServerPlayerEntity.class, ServerWorld.class));
+        } else {
+            INVOKER = invoker;
+        }
+    }
+}

--- a/src/main/java/carpetextra/helpers/PlayerForInteractions.java
+++ b/src/main/java/carpetextra/helpers/PlayerForInteractions.java
@@ -27,11 +27,9 @@ public class PlayerForInteractions {
         }
     }
     /**
-     * Holds either a Direct* {@link MethodHandle} to Fabric API's FakePlayer.get(ServerWorld) method, or
+     * Holds either a Direct {@link MethodHandle} to Fabric API's FakePlayer.get(ServerWorld) method, or
      * a constant {@link MethodHandle} that simply returns {@code null} if that API isn't available, which
-     * is good enough given we handle passing {@code null} to where vanilla would fail ourselves.<br>
-     * 
-     * * Not truly Direct given we need to adapt its return type to not use a type from them
+     * is good enough given we handle passing {@code null} to where vanilla would fail ourselves.
      */
     private static final MethodHandle INVOKER; // setup at the end
 


### PR DESCRIPTION
Supersedes #283.

This PR makes Carpet Extra use Fabric API's new stub players (confusingly called `FakePlayer` in the API) for `dispensersToggleThings` if the API is available. Otherwise, it keeps using `null` and handling `null` where vanilla doesn't.

The API access is done via a constant MethodHandle that will directly either call the api or return null. Constant MethodHandles can even be inlined to a plain call, so this should ensure no performance loss vs directly calling the api.

Vs #283, this:
- Uses a standard API for doing this, which is likely to further increase compatibility
- Respects that a player has properties like the World and not have the same for all dimensions in all worlds joined (singleplayer)
- Doesn't make us reimplement a stub player that may have many methods a mod would want to use that we'd have to patch
- Leaks a lot more! I've found a bug on fapi where creating one of these will make its world leak, and given we're now respecting what world they're in, they'll all be leaked! Yay!

I'll hold on merging until this last point is resolved in Fabric API, but otherwise this is ready.