### PR TITLE
Change so hoppers respect shulker box stack size in 1.19.4

### DIFF
--- a/src/main/java/carpetextra/mixins/ItemStackMixin.java
+++ b/src/main/java/carpetextra/mixins/ItemStackMixin.java
@@ -26,7 +26,6 @@ public abstract class ItemStackMixin
         if (CarpetExtraSettings.emptyShulkerBoxStackAlways && this.getItem() instanceof BlockItem)
         {
             BlockItem item = (BlockItem) this.getItem();
-
             if (item.getBlock() instanceof ShulkerBoxBlock &&
                 InventoryUtils.shulkerBoxHasItems((ItemStack) (Object) this) == false)
             {


### PR DESCRIPTION
This makes hoppers respect the configurable shulker box stack size, instead of always being 64