### PR TITLE
Allow giant mushroom generation to replace end portal frames

### DIFF
--- a/src/main/java/carpetextra/CarpetExtraSettings.java
+++ b/src/main/java/carpetextra/CarpetExtraSettings.java
@@ -269,4 +269,9 @@ public class CarpetExtraSettings
             validators = Validators.NonNegativeNumber.class
     )
     public static int xpPerSculkCatalyst = 5;
+
+    @Rule(
+            categories = {EXTRA, EXPERIMENTAL}
+    )
+    public static boolean giantMushroomReplaceEndPortalFrame = false;
 }

--- a/src/main/java/carpetextra/mixins/GiantMushroomReplaceEndPortalFrameMixin.java
+++ b/src/main/java/carpetextra/mixins/GiantMushroomReplaceEndPortalFrameMixin.java
@@ -1,0 +1,25 @@
+package carpetextra.mixins;
+
+import carpetextra.CarpetExtraSettings;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.registry.tag.TagKey;
+import net.minecraft.world.gen.feature.HugeMushroomFeature;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(HugeMushroomFeature.class)
+public class GiantMushroomReplaceEndPortalFrameMixin {
+    @Redirect(
+            method = "generateStem(Lnet/minecraft/world/WorldAccess;Lnet/minecraft/util/math/BlockPos$Mutable;Lnet/minecraft/block/BlockState;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/BlockState;isIn(Lnet/minecraft/registry/tag/TagKey;)Z"
+            )
+    )
+    private boolean redirectIsIn(BlockState state, TagKey<Block> tag) {
+        return state.isIn(tag) || (CarpetExtraSettings.giantMushroomReplaceEndPortalFrame && state.isOf(Blocks.END_PORTAL_FRAME));
+    }
+}

--- a/src/main/resources/assets/carpet-extra/lang/en_us.json
+++ b/src/main/resources/assets/carpet-extra/lang/en_us.json
@@ -195,5 +195,8 @@
   "carpet.rule.y0DragonEggBedrockBreaking.extra.0": "Requires dragonEggBedrockBreaking to be set to true.",
 
   //xpPerSculkCatalyst
-  "carpet.rule.xpPerSculkCatalyst.desc": "Sets the amount of xp dropped when breaking a sculk catalyst."
+  "carpet.rule.xpPerSculkCatalyst.desc": "Sets the amount of xp dropped when breaking a sculk catalyst.",
+
+  // giantMushroomReplaceEndPortalFrame
+  "carpet.rule.giantMushroomReplaceEndPortalFrame.desc": "Giant mushroom generation can replace end portal frames."
 }

--- a/src/main/resources/assets/carpet-extra/lang/zh_cn.json
+++ b/src/main/resources/assets/carpet-extra/lang/zh_cn.json
@@ -157,5 +157,8 @@
   "carpet.rule.blazeMeal.extra.0": "可通过发射器或玩家右键动作来催熟",
 
   "carpet.rule.disablePhantomSpawning.name": "禁止幻翼生成",
-  "carpet.rule.disablePhantomSpawning.desc": "禁止幻翼的生成"
+  "carpet.rule.disablePhantomSpawning.desc": "禁止幻翼的生成",
+
+  "carpet.rule.giantMushroomReplaceEndPortalFrame.name": "蘑菇方块允许代替末地传送门框架",
+  "carpet.rule.giantMushroomReplaceEndPortalFrame.desc": "小蘑菇长大时允许代替末地传送门框架"
 }

--- a/src/main/resources/assets/carpet-extra/lang/zh_tw.json
+++ b/src/main/resources/assets/carpet-extra/lang/zh_tw.json
@@ -161,5 +161,8 @@
 
   "carpet.rule.renewableIce.name": "可壓縮冰塊",
   "carpet.rule.renewableIce.desc": "當複數冰塊被掉落鐵砧砸到，將會壓縮成更高密度冰",
-  "carpet.rule.renewableIce.extra.0": "霜冰變成普通冰，普通變成冰磚，冰磚變成藍冰"
+  "carpet.rule.renewableIce.extra.0": "霜冰變成普通冰，普通變成冰磚，冰磚變成藍冰",
+
+  "carpet.rule.giantMushroomReplaceEndPortalFrame.name": "蘑菇方塊允許代替末地傳送門框架",
+  "carpet.rule.giantMushroomReplaceEndPortalFrame.desc": "小蘑菇長大時允許代替末地傳送門框架"
 }

--- a/src/main/resources/carpet-extra.mixins.json
+++ b/src/main/resources/carpet-extra.mixins.json
@@ -67,7 +67,8 @@
     "CactusBlock_fertilizerMixin",
     "LilyPadBlock_fertilizerMixin",
     "DispenserBlock_fallingBlockMixin",
-    "FallingBlockEntityAccessor"
+    "FallingBlockEntityAccessor",
+    "GiantMushroomReplaceEndPortalFrameMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This long-standing bug was patched in 1.21.5...

Modifying the block tag for `REPLACEABLE_BY_MUSHROOMS` would be a cleaner fix but it seems like everything in this mod is a mixin. 

This is my first time doing anything Minecraft mod related so please let me know if I've made mistakes or my code style needs fixing. I've tested it on 1.21.5 and the flag works :)