### PR TITLE
Port for 1.21.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-	id 'fabric-loom' version '1.10-SNAPSHOT'
-	id 'maven-publish'
+	id 'fabric-loom' version '1.11-SNAPSHOT'
+	 id 'maven-publish'
 }
 
 repositories {
 	maven {
-		url 'https://masa.dy.fi/maven'
+		url = 'https://masa.dy.fi/maven'
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,16 +3,18 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.21.6
-	yarn_mappings=1.21.6+build.1
-	loader_version=0.16.14
+	minecraft_version=1.21.9
+	yarn_mappings=1.21.9+build.1
+	loader_version=0.17.2
+	loom_version=1.11-SNAPSHOT
+	fabric_api_version=0.134.0+1.21.9
+	fabric_version=0.134.0+1.21.9
+
 	# check available versions on maven (https://masa.dy.fi/maven/carpet/fabric-carpet/) for the given minecraft version you are using
-	carpet_core_version=1.4.176+v250617
-	# for gametests
-	fabric_api_version=0.127.1+1.21.6
+	carpet_core_version=1.4.185+v250930
 
 # Mod Properties
-	mod_version = 1.4.176
+	mod_version = 1.4.177
 	maven_group = carpet-extra
 	archives_base_name = carpet-extra
 
@@ -20,7 +22,7 @@ org.gradle.jvmargs=-Xmx1G
 	# The Curseforge versions "names" or ids for the main branch (comma separated: 1.16.4,1.16.5)
 	# This is needed because CF uses too vague names for prereleases and release candidates
 	# Can also be the version ID directly coming from https://minecraft.curseforge.com/api/game/versions?token=[API_TOKEN]
-	release-curse-versions = Minecraft 1.21:1.21.6
+	release-curse-versions = Minecraft 1.21:1.21.9
 	# Whether or not to build another branch on release
 	release-extra-branch = false
 	# The name of the second branch to release

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/carpetextra/dispenser/behaviors/DragonBreathDispenserBehavior.java
+++ b/src/main/java/carpetextra/dispenser/behaviors/DragonBreathDispenserBehavior.java
@@ -30,7 +30,8 @@ public class DragonBreathDispenserBehavior extends FallibleItemDispenserBehavior
 
             // spawn some dragon breath particles around end stone
             Vec3d center = Vec3d.ofCenter(frontBlockPos);
-            world.spawnParticles(ParticleTypes.DRAGON_BREATH, center.getX(), center.getY(), center.getZ(), 10, 0.5, 0.5, 0.5, 0.01);
+//            TODO: Replace with actual dragons breath particle
+            world.spawnParticles(ParticleTypes.EXPLOSION, center.getX(), center.getY(), center.getZ(), 10, 0.5, 0.5, 0.5, 0.01);
 
             // decrement dragon breath and return
             stack.decrement(1);

--- a/src/main/java/carpetextra/dispenser/behaviors/FeedAnimalDispenserBehavior.java
+++ b/src/main/java/carpetextra/dispenser/behaviors/FeedAnimalDispenserBehavior.java
@@ -63,7 +63,7 @@ public class FeedAnimalDispenserBehavior extends FallibleItemDispenserBehavior {
                 // grow up baby animal slightly
                 animal.growUp((int)(-animal.getBreedingAge() / 200), true);
                 // spawn growth sparkle particle
-                animal.getWorld().addParticleClient(ParticleTypes.HAPPY_VILLAGER, animal.getParticleX(1.0D), animal.getRandomBodyY() + 0.5D, animal.getParticleZ(1.0D), 0.0D, 0.0D, 0.0D);
+                animal.getEntityWorld().addParticleClient(ParticleTypes.HAPPY_VILLAGER, animal.getParticleX(1.0D), animal.getRandomBodyY() + 0.5D, animal.getParticleZ(1.0D), 0.0D, 0.0D, 0.0D);
 
                 // eat item
                 return eatItem(animal, foodStack);

--- a/src/main/java/carpetextra/dispenser/behaviors/FeedMooshroomDispenserBehavior.java
+++ b/src/main/java/carpetextra/dispenser/behaviors/FeedMooshroomDispenserBehavior.java
@@ -12,7 +12,6 @@ import net.minecraft.component.type.SuspiciousStewEffectsComponent;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.passive.MooshroomEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.particle.ParticleTypes;
 import net.minecraft.predicate.entity.EntityPredicates;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
@@ -52,8 +51,9 @@ public class FeedMooshroomDispenserBehavior extends FallibleItemDispenserBehavio
                         mooshroomAccessor.setStewEffects(effect.get());
 
                         // play sound effect and show particles
+//                         TODO: Fix particle
                         world.playSound(null, frontBlockPos, SoundEvents.ENTITY_MOOSHROOM_EAT, SoundCategory.NEUTRAL, 2.0F, 1.0F);
-                        world.spawnParticles(ParticleTypes.EFFECT, mooshroom.getX() + mooshroom.getRandom().nextDouble() / 2.0D, mooshroom.getBodyY(0.5D), mooshroom.getZ() + mooshroom.getRandom().nextDouble() / 2.0D, 1, 0.0D, mooshroom.getRandom().nextDouble() / 5.0D, 0.0D, 0.01D);
+//                        world.spawnParticles(ParticleTypes.EFFECT, mooshroom.getX() + mooshroom.getRandom().nextDouble() / 2.0D, mooshroom.getBodyY(0.5D), mooshroom.getZ() + mooshroom.getRandom().nextDouble() / 2.0D, 1, 0.0D, mooshroom.getRandom().nextDouble() / 5.0D, 0.0D, 0.01D);
 
                         // remove a flower and return stack
                         stack.decrement(1);

--- a/src/main/java/carpetextra/mixins/ChickenEntityMixin.java
+++ b/src/main/java/carpetextra/mixins/ChickenEntityMixin.java
@@ -25,12 +25,12 @@ public abstract class ChickenEntityMixin extends AnimalEntity
     @Override
     public ActionResult interactMob(PlayerEntity player, Hand hand)
     {
-        if (this.getWorld() instanceof ServerWorld sw)
+        if (this.getEntityWorld() instanceof ServerWorld sw)
         {
             ItemStack stack = player.getStackInHand(hand);
             if (CarpetExtraSettings.chickenShearing && stack.getItem() == Items.SHEARS && !this.isBaby())
             {
-                boolean tookDamage = this.damage(sw, player.getWorld().getDamageSources().generic(), 1);
+                boolean tookDamage = this.damage(sw, player.getEntityWorld().getDamageSources().generic(), 1);
                 if (tookDamage)
                 {
                     this.dropItem(sw, Items.FEATHER);

--- a/src/main/java/carpetextra/mixins/ComparatorBlock_comparatorBetterItemFramesMixin.java
+++ b/src/main/java/carpetextra/mixins/ComparatorBlock_comparatorBetterItemFramesMixin.java
@@ -51,12 +51,12 @@ public abstract class ComparatorBlock_comparatorBetterItemFramesMixin extends Ab
             BlockPos blockPos = pos.offset(direction);
             BlockState blockState = world.getBlockState(blockPos);
             if (blockState.hasComparatorOutput()) {
-                i = blockState.getComparatorOutput(world, blockPos);
+                i = blockState.getComparatorOutput(world, blockPos, direction);
             } else if (i < 15 && blockState.isSolidBlock(world, blockPos)) {
                 blockPos = blockPos.offset(direction);
                 blockState = world.getBlockState(blockPos);
                 ItemFrameEntity itemFrameEntity = getAttachedItemFrameHorizontal(world, direction, blockPos);
-                int j = Math.max(itemFrameEntity == null ? -2147483648 : itemFrameEntity.getComparatorPower(), blockState.hasComparatorOutput() ? blockState.getComparatorOutput(world, blockPos) : -2147483648);
+                int j = Math.max(itemFrameEntity == null ? -2147483648 : itemFrameEntity.getComparatorPower(), blockState.hasComparatorOutput() ? blockState.getComparatorOutput(world, blockPos, direction) : -2147483648);
                 if (j != -2147483648) {
                     i = j;
                 }

--- a/src/main/java/carpetextra/mixins/DropperBlock_craftingMixin.java
+++ b/src/main/java/carpetextra/mixins/DropperBlock_craftingMixin.java
@@ -22,6 +22,7 @@ import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -40,7 +41,7 @@ public class DropperBlock_craftingMixin extends DispenserBlock
     }
 
     @Override
-    public int getComparatorOutput(BlockState state, World world, BlockPos pos)
+    public int getComparatorOutput(BlockState state, World world, BlockPos pos, Direction direction)
     {
         if (CarpetExtraSettings.autoCraftingDropper)
         {
@@ -59,7 +60,7 @@ public class DropperBlock_craftingMixin extends DispenserBlock
                 }
             }
         }
-        return super.getComparatorOutput(state, world, pos);
+        return super.getComparatorOutput(state, world, pos, direction);
     }
 
     @Unique private void spawn(World world, double x, double y, double z, ItemStack stack) {

--- a/src/main/java/carpetextra/mixins/FallingBlockEntityMixin.java
+++ b/src/main/java/carpetextra/mixins/FallingBlockEntityMixin.java
@@ -53,7 +53,7 @@ public abstract class FallingBlockEntityMixin extends Entity
     {
         if (getBlockState().isIn(BlockTags.ANVIL))
         {
-            World world = this.getWorld();
+            World world = this.getEntityWorld();
             if (CarpetExtraSettings.renewableIce)
             {
                 Block below = world.getBlockState(BlockPos.ofFloored(this.getX(), this.getY() - 0.059999999776482582D, this.getZ())).getBlock();

--- a/src/main/java/carpetextra/mixins/FallingBlockMixin.java
+++ b/src/main/java/carpetextra/mixins/FallingBlockMixin.java
@@ -43,7 +43,7 @@ public abstract class FallingBlockMixin extends Block
                 if (!DragonEggBedrockBreaking.fallInstantly &&
                         world.shouldTickEntityAt(pos))
                 {
-                    if (!world.isClient)
+                    if (!world.isClient())
                     {
                         FallingBlockEntity fallingBlock = FallingBlockEntity.spawnFromBlock(world, pos, world.getBlockState(pos) );
                         this.configureFallingBlockEntity(fallingBlock);

--- a/src/main/java/carpetextra/mixins/HopperMinecartEntity_transferItemsOutFeatureMixin.java
+++ b/src/main/java/carpetextra/mixins/HopperMinecartEntity_transferItemsOutFeatureMixin.java
@@ -57,7 +57,7 @@ public abstract class HopperMinecartEntity_transferItemsOutFeatureMixin extends 
     @Unique private static final Vec3d ascending_south_offset = new Vec3d( 0, 1, -1).normalize().multiply(-1);
 
     @Unique private Vec3d getBlockBelowCartOffset() {
-        BlockState state = this.getWorld().getBlockState(BlockPos.ofFloored(this.getPos()));
+        BlockState state = this.getEntityWorld().getBlockState(BlockPos.ofFloored(this.getEntityPos()));
         if (state.isIn(BlockTags.RAILS)) {
             RailShape railShape = state.get(((AbstractRailBlock)state.getBlock()).getShapeProperty());
             return switch (railShape) {
@@ -77,7 +77,7 @@ public abstract class HopperMinecartEntity_transferItemsOutFeatureMixin extends 
         Vec3d offsetToInventory = getBlockBelowCartOffset();
         //The visual rotation point of the minecart is roughly 0.5 above its feet (determined visually ingame)
         //Search 0.5 Blocks below the feet for an inventory
-        Inventory inv =  HopperBlockEntity.getInventoryAt(this.getWorld(), BlockPos.ofFloored(this.getPos().add(offsetToInventory)));
+        Inventory inv =  HopperBlockEntity.getInventoryAt(this.getEntityWorld(), BlockPos.ofFloored(this.getEntityPos().add(offsetToInventory)));
 
         //There is probably a way nicer way to determine the access side of the target inventory
         if (inv instanceof BlockEntity be) {

--- a/src/main/java/carpetextra/mixins/ItemFrameEntity_comparatorBetterItemFramesMixin.java
+++ b/src/main/java/carpetextra/mixins/ItemFrameEntity_comparatorBetterItemFramesMixin.java
@@ -22,14 +22,14 @@ public abstract class ItemFrameEntity_comparatorBetterItemFramesMixin extends Ab
     @Inject(method = "setHeldItemStack(Lnet/minecraft/item/ItemStack;Z)V", at = @At(value = "INVOKE", target="Lnet/minecraft/world/World;updateComparators(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/Block;)V"), cancellable = true)
     private void onStackChangeUpdateComparatorDownwards(ItemStack value, boolean update, CallbackInfo ci) {
         if (CarpetExtraSettings.comparatorBetterItemFrames == ComparatorOptions.EXTENDED) {
-            this.getWorld().updateComparators(this.attachedBlockPos.offset(this.getHorizontalFacing().getOpposite()), Blocks.AIR);
+            this.getEntityWorld().updateComparators(this.attachedBlockPos.offset(this.getHorizontalFacing().getOpposite()), Blocks.AIR);
         }
     }
 
     @Inject(method = "setRotation(IZ)V", at = @At(value = "INVOKE", target="Lnet/minecraft/world/World;updateComparators(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/Block;)V"), cancellable = true)
     private void onRotationUpdateComparatorDownwards(int value, boolean bl, CallbackInfo ci) {
         if (CarpetExtraSettings.comparatorBetterItemFrames == ComparatorOptions.EXTENDED) {
-            this.getWorld().updateComparators(this.attachedBlockPos.offset(this.getHorizontalFacing().getOpposite()), Blocks.AIR);
+            this.getEntityWorld().updateComparators(this.attachedBlockPos.offset(this.getHorizontalFacing().getOpposite()), Blocks.AIR);
         }
     }
 }

--- a/src/main/java/carpetextra/mixins/ItemFrameEntity_comparatorReadsClockMixin.java
+++ b/src/main/java/carpetextra/mixins/ItemFrameEntity_comparatorReadsClockMixin.java
@@ -29,7 +29,7 @@ public abstract class ItemFrameEntity_comparatorReadsClockMixin extends Abstract
         if(CarpetExtraSettings.comparatorReadsClock && this.getHeldItemStack().getItem() == Items.CLOCK) {
             int power;
             //Every 1500 ticks, increase signal strength by one
-            power = (int)(this.getWorld().getTimeOfDay() % 24000) / 1500;
+            power = (int)(this.getEntityWorld().getTimeOfDay() % 24000) / 1500;
             //in case negative time of day every happens, make comparator output the according positive value
             if(power < 0)
                 power = power + 16;
@@ -43,10 +43,10 @@ public abstract class ItemFrameEntity_comparatorReadsClockMixin extends Abstract
         if(CarpetExtraSettings.comparatorReadsClock && this.getHeldItemStack().getItem() == Items.CLOCK) {
             //This doesn't handle time set commands yet
             //Every 1500 ticks, increase signal strength by one, so update comparators exactly then
-            if(this.getWorld().getTimeOfDay() % 1500 == 0 || firstTick) {
+            if(this.getEntityWorld().getTimeOfDay() % 1500 == 0 || firstTick) {
                 firstTick = false;
                 if(this.attachedBlockPos != null) {
-                    this.getWorld().updateComparators(this.attachedBlockPos, Blocks.AIR);
+                    this.getEntityWorld().updateComparators(this.attachedBlockPos, Blocks.AIR);
                 }
             }
         }

--- a/src/main/java/carpetextra/mixins/LivingEntityMixin.java
+++ b/src/main/java/carpetextra/mixins/LivingEntityMixin.java
@@ -40,21 +40,21 @@ public abstract class LivingEntityMixin extends Entity
             return;
         
         BlockPos pos = BlockPos.ofFloored(this.getX(), this.getY(), this.getZ());
-        BlockState statePos = this.getWorld().getBlockState(pos);
-        
+        BlockState statePos = this.getEntityWorld().getBlockState(pos);
+
         BlockPos below = pos.down(1);
-        BlockState stateBelow = this.getWorld().getBlockState(below);
+        BlockState stateBelow = this.getEntityWorld().getBlockState(below);
         
         if (statePos.getBlock() == Blocks.FIRE && stateBelow.isIn(BlockTags.SAND))
         {
-            this.getWorld().setBlockState(below, Blocks.SOUL_SAND.getDefaultState());
+            this.getEntityWorld().setBlockState(below, Blocks.SOUL_SAND.getDefaultState());
         }
     }
 
     @Inject(method = "onDeath", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/damage/DamageSource;getAttacker()Lnet/minecraft/entity/Entity;"))
     private void onOnDeath(DamageSource source, CallbackInfo ci)
     {
-        if (this.getWorld() instanceof ServerWorld sw)
+        if (this.getEntityWorld() instanceof ServerWorld sw)
         {
             if ((this.getVehicle() instanceof SpiderEntity) && this.random.nextInt(100) + 1 < CarpetExtraSettings.spiderJockeysDropGapples)
             {

--- a/src/main/java/carpetextra/mixins/SkeletonEntityMixin.java
+++ b/src/main/java/carpetextra/mixins/SkeletonEntityMixin.java
@@ -23,7 +23,7 @@ public abstract class SkeletonEntityMixin extends AbstractSkeletonEntity
     @Override
     public void onStruckByLightning(ServerWorld world, LightningEntity entity)
     {
-        if (!world.isClient && !this.isRemoved() && CarpetExtraSettings.renewableWitherSkeletons)
+        if (!world.isClient() && !this.isRemoved() && CarpetExtraSettings.renewableWitherSkeletons)
         {
             WitherSkeletonEntity witherSkelly = new WitherSkeletonEntity(EntityType.WITHER_SKELETON, world);
             witherSkelly.refreshPositionAndAngles(this.getX(), this.getY(), this.getZ(), this.getYaw(), this.getPitch());
@@ -44,7 +44,7 @@ public abstract class SkeletonEntityMixin extends AbstractSkeletonEntity
                 this.stopRiding();
                 witherSkelly.extinguish();
                 mount.extinguish();
-                witherSkelly.startRiding(mount, true);
+                witherSkelly.startRiding(mount);
             }
             this.discard();
         }

--- a/src/main/java/carpetextra/mixins/SpiderEntityMixin.java
+++ b/src/main/java/carpetextra/mixins/SpiderEntityMixin.java
@@ -22,7 +22,7 @@ public abstract class SpiderEntityMixin extends HostileEntity
     @Override
     public void onDeath(DamageSource source)
     {
-        if (this.getWorld() instanceof ServerWorld sw)
+        if (this.getEntityWorld() instanceof ServerWorld sw)
         {
             if (this.hasPassengers() && this.random.nextInt(100) + 1 < CarpetExtraSettings.spiderJockeysDropGapples)
             {


### PR DESCRIPTION
Quick and dirty port from 1.21.6 to 1.21.9, including upgrading Gradle to 8.14 as per the latest Fabric release

Currently the particles for dispensing a flower to a Brown Mooshroom and converting Cobblestone to Endstone are broken. Cobblestone to Endstone uses a small explosion particle as a placeholder, but the Brown Mooshroom has no particles