### PR TITLE
Align dispenser boat placement on ice with vanilla waterlogged behavior

### DIFF
--- a/src/main/java/carpetextra/dispenser/CarpetExtraDispenserBehaviors.java
+++ b/src/main/java/carpetextra/dispenser/CarpetExtraDispenserBehaviors.java
@@ -243,9 +243,14 @@ public class CarpetExtraDispenserBehaviors {
         }
 
         // dispensersPlaceBoatsOnIce
-        if (CarpetExtraSettings.dispensersPlaceBoatsOnIce && item instanceof BoatItem && frontBlock == Blocks.AIR) {
-            BlockPos blockBelowFrontBlockPos = frontBlockPos.down();
-            if (world.getBlockState(blockBelowFrontBlockPos).isIn(BlockTags.ICE)) {
+        if (CarpetExtraSettings.dispensersPlaceBoatsOnIce && item instanceof BoatItem) {
+            BlockState frontState = world.getBlockState(frontBlockPos);
+
+            boolean iceInFront = frontState.isIn(BlockTags.ICE);
+            boolean airInFront = frontState.isAir();
+            boolean iceBelowFront = world.getBlockState(frontBlockPos.down()).isIn(BlockTags.ICE);
+
+            if (iceInFront || (airInFront && iceBelowFront)) {
                 return PLACE_BOAT_ON_ICE;
             }
         }


### PR DESCRIPTION
This pull request updates the existing `dispensersPlaceBoatsOnIce` rule so that dispenser boat placement on ice follows the same logic that vanilla applies when placing boats into water or waterlogged blocks.

### Summary of changes
- Ice directly in front of a dispenser now applies the same upward placement offset that vanilla uses for waterlogged blocks
- When air is in front and ice is one block below, boats are placed at the normal height, matching vanilla behavior for air-over-water
- Extends vanilla BoatDispenserBehavior logic to ice while preserving all original placement conditions and offsets

### Linked issue
Fixes #358

### Testing
I tested this feature extensively to ensure full parity with vanilla behavior:

- Ice directly in front
- Ice one block below front
- Dispensers facing all directions
- Dispensers above and below ice
- Waterlogged blocks with:
  - solid blocks in front
  - slabs in front
  - slabs above
  - full blocks above
- Mixed configurations of ice, air, and blocks
- All combinations verified to match vanilla boat placement logic where applicable

Screenshot of the tests is attached below.

<img width="2560" height="1351" alt="2025-11-11_16 15 26" src="https://github.com/user-attachments/assets/6c386bfe-5790-4895-a300-ee7d645d4e22" />
