### PR TITLE
Update to Minecraft 1.21.10 and latest dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.11-SNAPSHOT'
+	id 'fabric-loom' version '1.13-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
-	minecraft_version=1.21.9
-	yarn_mappings=1.21.9+build.1
-	loader_version=0.17.2
+	minecraft_version=1.21.10
+	yarn_mappings=1.21.10+build.2
+	loader_version=0.17.3
 	
 	# check available versions on maven (https://masa.dy.fi/maven/carpet/fabric-carpet/) for the given minecraft version you are using
-	carpet_core_version=1.4.185+v250930
+	carpet_core_version=1.4.188+v251016
 	# for gametests
-	fabric_api_version=0.134.0+1.21.9
+	fabric_api_version=0.138.3+1.21.10
 
 # Mod Properties
-	mod_version = 1.4.177
+	mod_version = 1.4.178
 	maven_group = carpet-extra
 	archives_base_name = carpet-extra
 
@@ -21,7 +21,7 @@ org.gradle.jvmargs=-Xmx1G
 	# The Curseforge versions "names" or ids for the main branch (comma separated: 1.16.4,1.16.5)
 	# This is needed because CF uses too vague names for prereleases and release candidates
 	# Can also be the version ID directly coming from https://minecraft.curseforge.com/api/game/versions?token=[API_TOKEN]
-	release-curse-versions = Minecraft 1.21:1.21.9
+	release-curse-versions = Minecraft 1.21:1.21.10
 	# Whether or not to build another branch on release
 	release-extra-branch = false
 	# The name of the second branch to release


### PR DESCRIPTION
- Updated Minecraft version to 1.21.10
- Updated Yarn mappings to 1.21.10+build.2
- Updated Fabric Loader to 0.17.3
- Updated Carpet Core to 1.4.188+v251016
- Updated Fabric API to 0.138.3+1.21.10
- Bumped mod version to 1.4.178
- Updated release target to Minecraft 1.21:1.21.10
- Updated Loom plugin from 1.11-SNAPSHOT to 1.13-SNAPSHOT